### PR TITLE
Add  event callbacks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import collectFs from "@dh-pub/collect-fs";
 collectFs(
   ["/path/to/one/directory", "/path/to/another/directory"],
   "/path/to/target/directory", function onEvent(eventData) {
-    /** @type {type: "add" | "change" | "unlink", data: Record<string, unknown>} */
+    /** @eventData {type: "add" | "change" | "unlink", payload: Record<string, unknown>} */
   }
 );
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ import collectFs from "@dh-pub/collect-fs";
 
 collectFs(
   ["/path/to/one/directory", "/path/to/another/directory"],
-  "/path/to/target/directory"
+  "/path/to/target/directory", function onEvent(eventData) {
+    /** @type {type: "add" | "change" | "unlink", data: Record<string, unknown>} */
+  }
 );
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dh-pub/collect-fs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Merge multiple directories in one. Precedence is based on arguments.",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,9 +171,9 @@ export default function collectFs(
       if (next) {
         await ensureDir(dirname(target));
         await promises.copyFile(next, target, constants.COPYFILE_FICLONE);
-        return;
+      } else {
+        await promises.unlink(target);
       }
-      await promises.unlink(target);
 
       if (onEvent) {
         onEvent({

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ export default function collectFs(
       if (onEvent) {
         onEvent({
           type: eventType,
-          payload: { filesStackCount: Object.keys(files).length },
+          payload: { filesStackCount: Object.keys(files).length, rel },
         });
       }
     };
@@ -178,7 +178,7 @@ export default function collectFs(
       if (onEvent) {
         onEvent({
           type: "unlink",
-          payload: { filesStackCount: Object.keys(files).length },
+          payload: { filesStackCount: Object.keys(files).length, rel },
         });
       }
     });


### PR DESCRIPTION
Add  onEvent callback, to track the **files** stack size. 

**onEvent** is needed, because we want an interactive dev. build.

If we track the **filesStackCount** we can identify if the initial merge is finished or not.